### PR TITLE
Move to .Net Standard2

### DIFF
--- a/Codeblaze.SemanticKernel.Connectors.Ollama/Codeblaze.SemanticKernel.Connectors.Ollama.csproj
+++ b/Codeblaze.SemanticKernel.Connectors.Ollama/Codeblaze.SemanticKernel.Connectors.Ollama.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>Latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
@@ -15,6 +16,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
+      <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     </ItemGroup>
 
     <!-- Nuget Stuff -->
@@ -43,8 +45,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <None Include="./README.md" Pack="true" PackagePath="/"/>
-      <None Include="../LICENSE.md" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+      <None Include="./README.md" Pack="true" PackagePath="/" />
+      <None Include="../LICENSE.md" Pack="true" PackagePath="$(PackageLicenseFile)" />
     </ItemGroup>
 
 </Project>

--- a/Codeblaze.SemanticKernel.Connectors.Ollama/EmbeddingGeneration/OllamaTextEmbeddingGeneration.cs
+++ b/Codeblaze.SemanticKernel.Connectors.Ollama/EmbeddingGeneration/OllamaTextEmbeddingGeneration.cs
@@ -30,7 +30,7 @@ public class OllamaTextEmbeddingGeneration(string modelId, string baseUrl, HttpC
 
             ValidateOllamaResponse(response);
 
-            var json = JsonSerializer.Deserialize<JsonNode>(await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+            var json = JsonSerializer.Deserialize<JsonNode>(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
 
             var embedding = new ReadOnlyMemory<float>(json!["embedding"]?.AsArray().GetValues<float>().ToArray());
             


### PR DESCRIPTION
## Motivation

In order to use OLLAMA with a maximum of .Net application, I suggest to deliver your package in .NET Standard2.0 which is more convenient for libraries rather than .NETCore8. 

## What changed

- Change the target framework to netstandard2.0
- Use System.Net.Http.Json NuGet package
- Adapt the code to support the NuGet package.

