### PR TITLE
Fix and improve streaming chat messages

### DIFF
--- a/dotnet/Codeblaze.SemanticKernel.Connectors.Ollama/ChatCompletion/OllamaChatCompletionService.cs
+++ b/dotnet/Codeblaze.SemanticKernel.Connectors.Ollama/ChatCompletion/OllamaChatCompletionService.cs
@@ -52,7 +52,9 @@ public class OllamaChatCompletionService(
             options = chatExecutionSettings
         };
 
-        var response = await Http.PostAsJsonAsync($"{Attributes["base_url"]}/api/chat", data, cancellationToken).ConfigureAwait(false);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"{Attributes["base_url"]}/api/chat");
+        request.Content = JsonContent.Create(data);
+        using var response = await Http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
 
         ValidateOllamaResponse(response);
 
@@ -64,7 +66,7 @@ public class OllamaChatCompletionService(
 
         while (!done)
         {
-            string jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            string jsonResponse = await reader.ReadLineAsync();
 
             var chatResponseMessage = JsonSerializer.Deserialize<OllamaChatResponseMessage>(jsonResponse);
             done = chatResponseMessage!.Done;


### PR DESCRIPTION
**Motivation and Context**
Inspired by and improving on #12 as a solution for #11 

The chat message content is not returned to caller until entire stream has been read.

**Description**
Instead of using `PostAsJsonAsync` use a basic `SendAsync `specifying `HttpCompletionOption.ResponseHeadersRead `  allowing the content to be read as soon as the HTTP response headers are received.